### PR TITLE
[SQUASH] base: Hide ADB and developer setting enable status [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -104,6 +104,8 @@ import android.widget.Editor;
 import com.android.internal.annotations.GuardedBy;
 import com.android.internal.util.Preconditions;
 
+import com.android.internal.util.axion.HideDeveloperStatusUtils;
+
 import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -4411,6 +4413,9 @@ public final class Settings {
         /** @hide */
         @UnsupportedAppUsage
         public static int getIntForUser(ContentResolver cr, String name, int def, int userHandle) {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getStringForUser(cr, name, userHandle);
             return parseIntSettingWithDefault(v, def);
         }
@@ -4442,6 +4447,9 @@ public final class Settings {
         @UnsupportedAppUsage
         public static int getIntForUser(ContentResolver cr, String name, int userHandle)
                 throws SettingNotFoundException {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getStringForUser(cr, name, userHandle);
             return parseIntSetting(v, name);
         }
@@ -7331,6 +7339,9 @@ public final class Settings {
         /** @hide */
         @UnsupportedAppUsage
         public static int getIntForUser(ContentResolver cr, String name, int def, int userHandle) {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getStringForUser(cr, name, userHandle);
             return parseIntSettingWithDefault(v, def);
         }
@@ -7361,6 +7372,9 @@ public final class Settings {
         /** @hide */
         public static int getIntForUser(ContentResolver cr, String name, int userHandle)
                 throws SettingNotFoundException {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getStringForUser(cr, name, userHandle);
             return parseIntSetting(v, name);
         }
@@ -12548,6 +12562,14 @@ public final class Settings {
          */
         public static final String HBM_SETTING_KEY =
                 "com.android.server.display.HBM_SETTING_KEY";
+
+
+        /**
+         * Control whether to hide ADB and Developer settings enable status.
+         * @hide
+         */
+        @Readable
+        public static final String HIDE_DEVELOPER_STATUS = "hide_developer_status";
 
         /**
          * Pulse navbar music visualizer
@@ -18628,6 +18650,9 @@ public final class Settings {
          * or not a valid integer.
          */
         public static int getInt(ContentResolver cr, String name, int def) {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getString(cr, name);
             return parseIntSettingWithDefault(v, def);
         }
@@ -18652,6 +18677,9 @@ public final class Settings {
          */
         public static int getInt(ContentResolver cr, String name)
                 throws SettingNotFoundException {
+            if (HideDeveloperStatusUtils.shouldHideDevStatus(cr, cr.getPackageName(), name)) {
+                return 0 /* Disabled */;
+            }
             String v = getString(cr, name);
             return parseIntSetting(v, name);
         }

--- a/core/java/com/android/internal/util/axion/HideDeveloperStatusUtils.java
+++ b/core/java/com/android/internal/util/axion/HideDeveloperStatusUtils.java
@@ -1,0 +1,110 @@
+package com.android.internal.util.axion;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.UserHandle;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import android.provider.Settings;
+
+public class HideDeveloperStatusUtils {
+    private static final Set<String> settingsToHide =
+        new HashSet<>(
+            Arrays.asList(
+                Settings.Global.ADB_ENABLED,
+                Settings.Global.ADB_WIFI_ENABLED,
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED
+            ));
+
+    enum Action {
+        ADD,
+        REMOVE,
+        SET
+    }
+
+    public static boolean shouldHideDevStatus(
+            ContentResolver cr, String packageName, String name) {
+        if (cr == null || packageName == null || name == null) {
+            return false;
+        }
+
+        Set<String> apps = getApps(cr);
+        if (apps.isEmpty()) {
+            return false;
+        }
+
+        return apps.contains(packageName) && settingsToHide.contains(name);
+    }
+
+    private static Set<String> getApps(Context context) {
+        if (context == null) {
+            return new HashSet<>();
+        }
+
+        return getApps(context.getContentResolver());
+    }
+
+    private static Set<String> getApps(ContentResolver cr) {
+        if (cr == null) {
+            return new HashSet<>();
+        }
+
+        String apps = Settings.Secure.getString(cr, Settings.Secure.HIDE_DEVELOPER_STATUS);
+        if (apps != null && !apps.isEmpty() && !apps.equals(",")) {
+            return new HashSet<>(Arrays.asList(apps.split(",")));
+        }
+
+        return new HashSet<>();
+    }
+
+    private static void putAppsForUser(
+            Context context, String packageName,
+            int userId, Action action) {
+        if (context == null || userId < 0) {
+            return;
+        }
+
+        final Set<String> apps = getApps(context);
+        switch (action) {
+            case ADD:
+                apps.add(packageName);
+                break;
+            case REMOVE:
+                apps.remove(packageName);
+                break;
+            case SET:
+                // Don't change
+                break;
+        }
+
+        Settings.Secure.putStringForUser(context.getContentResolver(),
+                Settings.Secure.HIDE_DEVELOPER_STATUS, String.join(",", apps), userId);
+    }
+
+    public void addApp(Context mContext, String packageName, int userId) {
+        if (mContext == null || packageName == null || userId < 0) {
+            return;
+        }
+
+        putAppsForUser(mContext, packageName, userId, Action.ADD);
+    }
+
+    public void removeApp(Context mContext, String packageName, int userId) {
+        if (mContext == null || packageName == null || userId < 0) {
+            return;
+        }
+
+        putAppsForUser(mContext, packageName, userId, Action.REMOVE);
+    }
+
+    public void setApps(Context mContext, int userId) {
+        if (mContext == null || userId < 0) {
+            return;
+        }
+
+        putAppsForUser(mContext, null, userId, Action.SET);
+    }
+}

--- a/packages/SettingsProvider/src/android/provider/settings/validators/SecureSettingsValidators.java
+++ b/packages/SettingsProvider/src/android/provider/settings/validators/SecureSettingsValidators.java
@@ -446,5 +446,6 @@ public class SecureSettingsValidators {
         VALIDATORS.put(Secure.MANDATORY_BIOMETRICS, new InclusiveIntegerRangeValidator(0, 1));
         VALIDATORS.put(Secure.MANDATORY_BIOMETRICS_REQUIREMENTS_SATISFIED,
                 new InclusiveIntegerRangeValidator(0, 1));
+        VALIDATORS.put(Secure.HIDE_DEVELOPER_STATUS, ANY_STRING_VALIDATOR);
     }
 }


### PR DESCRIPTION
* Some apps check whether ADB or developer setting is enabled
* Return 0 to selected apps when those apps getInt ADB_ENABLED, ADB_WIFI_ENABLED, DEVELOPMENT_SETTINGS_ENABLED
* Code is adapted and stripped down from cutout force full screen

Ref:
https://github.com/LineageOS/android_lineage-sdk/blob/lineage-16.0/sdk/src/java/org/lineageos/internal/applications/LongScreen.java https://github.com/yaap/frameworks_base/commit/232260f192effc9fb21a54eb444601179b24a26d



base: HideDevStatus: move to getIntForUser to cover more scenarios

* Adapt to current project as we want to set status individually per-app for case apps require ADB or Dev settings for their functionality

e.g. SystemUI Tuner by Zachary Wander
https://play.google.com/store/apps/details?id=com.zacharee1.systemuituner&hl=en_US&gl=US

Ref:
https://github.com/RisingTechOSS/android_frameworks_base/commit/77be7be42060dc5119c6dccef874c9a439aed210

Change-Id: Ibbf92c7b1f1181d2508cb22ff2fc2017f9e59706



base: HideDeveloperStatus: Query all apps installed by any user [1/2]

* And set value for all user

Change-Id: Ibd2a5dfab832e6bdc6d074ce41401f4905602152

base: HideDeveloperStatusUtils: Avoid NPE with mApps

* https://paste.evolution-x.org/P9Lj8g.

* Avoid NPE

From: someone5678 <someone5678@users.noreply.github.com>
fixup! base: Hide ADB and developer setting enable status [1/2]
* Clean-up and handle exceptions