### PR TITLE
BluetoothPowerStatsCollector: Handle onBluetoothActivityEnergyInfoError gracefully

### DIFF
--- a/services/core/java/com/android/server/power/stats/BluetoothPowerStatsCollector.java
+++ b/services/core/java/com/android/server/power/stats/BluetoothPowerStatsCollector.java
@@ -178,8 +178,8 @@ public class BluetoothPowerStatsCollector extends PowerStatsCollector {
 
                     @Override
                     public void onBluetoothActivityEnergyInfoError(int error) {
-                        immediateFuture.completeExceptionally(
-                                new RuntimeException("error: " + error));
+                        Slog.w(TAG, "BluetoothActivityEnergyInfo request failed with error code: " + error);
+                        immediateFuture.complete(null);
                     }
                 });
 
@@ -192,7 +192,7 @@ public class BluetoothPowerStatsCollector extends PowerStatsCollector {
             activityInfo = immediateFuture.get(BLUETOOTH_ACTIVITY_REQUEST_TIMEOUT,
                     TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            Slog.e(TAG, "Cannot acquire BluetoothActivityEnergyInfo", e);
+            Slog.w(TAG, "BluetoothActivityEnergyInfo unavailable, skipping stats collection", e);
             activityInfo = null;
         }
 


### PR DESCRIPTION
Avoids crashing or logging unhandled exceptions when the Bluetooth energy info callback returns an error. This ensures the stats collection proceeds even if BluetoothActivityEnergyInfo is unavailable or fails.

 E BluetoothPowerStatsCollector: Cannot acquire BluetoothActivityEnergyInfo
 E BluetoothPowerStatsCollector: java.util.concurrent.ExecutionException: java.lang.RuntimeException: error: 9
 E BluetoothPowerStatsCollector:  at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:372)
 E BluetoothPowerStatsCollector:  at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2072)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.BluetoothPowerStatsCollector.collectBluetoothActivityInfo(BluetoothPowerStatsCollector.java:192)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.BluetoothPowerStatsCollector.collectStats(BluetoothPowerStatsCollector.java:155)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.PowerStatsCollector.collectAndDeliverStats(PowerStatsCollector.java:176)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.PowerStatsCollector$$ExternalSyntheticLambda0.run(R8$$SyntheticClass:0)
 E BluetoothPowerStatsCollector:  at android.os.Handler.handleCallback(Handler.java:995)
 E BluetoothPowerStatsCollector:  at android.os.Handler.dispatchMessage(Handler.java:103)
 E BluetoothPowerStatsCollector:  at android.os.Looper.loopOnce(Looper.java:248)
 E BluetoothPowerStatsCollector:  at android.os.Looper.loop(Looper.java:338)
 E BluetoothPowerStatsCollector:  at android.os.HandlerThread.run(HandlerThread.java:85)
 E BluetoothPowerStatsCollector: Caused by: java.lang.RuntimeException: error: 9
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.BluetoothPowerStatsCollector$1.onBluetoothActivityEnergyInfoError(BluetoothPowerStatsCollector.java:181)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothAdapter$OnBluetoothActivityEnergyInfoProxy.lambda$onError$2(BluetoothAdapter.java:1059)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothAdapter$OnBluetoothActivityEnergyInfoProxy$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothUtils.lambda$executeFromBinder$0(BluetoothUtils.java:343)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothUtils$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
 E BluetoothPowerStatsCollector:  at com.android.server.SystemServerInitThreadPool$$ExternalSyntheticLambda0.execute(R8$$SyntheticClass:0)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothUtils.executeFromBinder(BluetoothUtils.java:343)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothAdapter$OnBluetoothActivityEnergyInfoProxy.onError(BluetoothAdapter.java:1058)
 E BluetoothPowerStatsCollector:  at android.bluetooth.BluetoothAdapter.requestControllerActivityEnergyInfo(BluetoothAdapter.java:2694)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.BatteryStatsImpl$BluetoothStatsRetrieverImpl.requestControllerActivityEnergyInfo(BatteryStatsImpl.java:485)
 E BluetoothPowerStatsCollector:  at com.android.server.power.stats.BluetoothPowerStatsCollector.collectBluetoothActivityInfo(BluetoothPowerStatsCollector.java:170)
 E BluetoothPowerStatsCollector:  ... 8 more

Change-Id: I143e701db08ab514c9f161445d515542c6a6cf71