### PR TITLE
display: Allow HBM in manual brightness if no time limitation

### DIFF
--- a/services/core/java/com/android/server/display/HighBrightnessModeController.java
+++ b/services/core/java/com/android/server/display/HighBrightnessModeController.java
@@ -379,8 +379,9 @@ class HighBrightnessModeController {
         // brightness maximum; so we implement HDR-HBM in a way that doesn't adjust the max.
         // See {@link #getHdrBrightnessValue}.
         return !mIsHdrLayerPresent
-                && (mIsAutoBrightnessEnabled && mIsTimeAvailable && mIsInAllowedAmbientRange
-                && !mIsBlockedByLowPowerMode);
+                && ((mIsAutoBrightnessEnabled && mIsTimeAvailable && mIsInAllowedAmbientRange)
+                    || (!mIsAutoBrightnessEnabled && mHbmData.timeWindowMillis == 0))
+                && !mIsBlockedByLowPowerMode;
     }
 
     boolean deviceSupportsHbm() {


### PR DESCRIPTION
If a display does not set time limitation for HBM, it means it can safely run at HBM for as long as it wants. With this in mind, we can allow HBM in manual brightness too for such displays. This still obeys the thermal throttling and battery saver conditions for obvious reasons.

Change-Id: I18ca7748c1f32dca1e70497afd0b6df8ed81ad5d