### PR TITLE
AxDynamicBar: Align lockscreen chip with keyguard indication margin

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/AxDynamicBarKeyguardChipSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/AxDynamicBarKeyguardChipSection.kt
@@ -97,17 +97,17 @@ constructor(
                         lp.width = ViewGroup.LayoutParams.WRAP_CONTENT
                         lp.height = ViewGroup.LayoutParams.WRAP_CONTENT
                         lp.topMargin = 0
-                        
-                        lp.bottomToBottom = R.id.start_button
+
+                        lp.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                        lp.bottomMargin = context.resources.getDimensionPixelSize(R.dimen.keyguard_indication_margin_bottom)
                         lp.topToTop = -1
-                        
-                        lp.startToEnd = R.id.start_button
-                        lp.endToStart = R.id.end_button
-                        lp.bottomMargin = 0
-                        
+
+                        lp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+                        lp.endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
+                        lp.startToEnd = -1
+                        lp.endToStart = -1
+
                         lp.bottomToTop = -1
-                        lp.startToStart = -1
-                        lp.endToEnd = -1
                         lp.topToBottom = -1
                     }
                     composeView.layoutParams = lp
@@ -131,11 +131,10 @@ constructor(
             } else {
                 constrainWidth(chipViewId, ViewGroup.LayoutParams.WRAP_CONTENT)
                 constrainHeight(chipViewId, ViewGroup.LayoutParams.WRAP_CONTENT)
-                
-                connect(chipViewId, ConstraintSet.BOTTOM, R.id.start_button, ConstraintSet.BOTTOM)
-                
-                connect(chipViewId, ConstraintSet.START, R.id.start_button, ConstraintSet.END)
-                connect(chipViewId, ConstraintSet.END, R.id.end_button, ConstraintSet.START)
+                val marginBottom = context.resources.getDimensionPixelSize(R.dimen.keyguard_indication_margin_bottom)
+                connect(chipViewId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM, marginBottom)
+                connect(chipViewId, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+                connect(chipViewId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
             }
         }
     }


### PR DESCRIPTION
On devices with a low-positioned UDFPS icon, the lockscreen chip can overlap and render behind it in collapsed mode.

Align the chip with the keyguard indication margin and use the `keyguard_indication_margin_bottom` overlay to adjust placement per device as needed.

Change-Id: I4f253bc37ba3f565f4c480ce30a4f3beabfc7d9e