### PR TITLE
wm: DisplayRotation: Preserve locked rotation during screen state changes

### DIFF
--- a/services/core/java/com/android/server/wm/DisplayRotation.java
+++ b/services/core/java/com/android/server/wm/DisplayRotation.java
@@ -549,6 +549,15 @@ public class DisplayRotation {
         final int lastOrientation = mLastOrientation;
         @Surface.Rotation
         int rotation = rotationForOrientation(lastOrientation, oldRotation);
+
+        // Preserve locked user rotation across screen off/on and keyguard
+        if (mUserRotationMode == WindowManagerPolicy.USER_ROTATION_LOCKED) {
+            rotation = mUserRotation;
+            ProtoLog.v(WM_DEBUG_ORIENTATION,
+                    "Forcing locked user rotation=%s (%d)",
+                    Surface.rotationToString(rotation), rotation);
+        }
+
         // Use the saved rotation for tabletop mode, if set.
         if (mFoldController != null && mFoldController.shouldRevertOverriddenRotation()) {
             int prevRotation = rotation;


### PR DESCRIPTION
When auto-rotation is disabled, turning the screen off and waking it back up can sometimes cause the device to rotate back to its default orientation. For example, a tablet locked in landscape might wake up in portrait.

This happens because the system recalculates the display rotation during lockscreen and screen power transitions, accidentally ignoring the user's locked choice.

To fix this, we now check if the user locked the rotation. If they did, we ignore the system's recalculation and just apply the exact orientation the user originally saved.

Change-Id: Id64e9c0498c1269bd98922409d1757734e203c78