### PR TITLE
telephony: Relax default 5G NR SA SS-RSRP signal strength thresholds

### DIFF
--- a/telephony/java/android/telephony/CarrierConfigManager.java
+++ b/telephony/java/android/telephony/CarrierConfigManager.java
@@ -11548,10 +11548,10 @@ public class CarrierConfigManager {
         sDefaults.putIntArray(KEY_5G_NR_SSRSRP_THRESHOLDS_INT_ARRAY,
                 // Boundaries: [-140 dB, -44 dB]
                 new int[] {
-                    -110, /* SIGNAL_STRENGTH_POOR */
-                    -90,  /* SIGNAL_STRENGTH_MODERATE */
-                    -80,  /* SIGNAL_STRENGTH_GOOD */
-                    -65,  /* SIGNAL_STRENGTH_GREAT */
+                    -125, /* SIGNAL_STRENGTH_POOR */
+                    -115,  /* SIGNAL_STRENGTH_MODERATE */
+                    -105,  /* SIGNAL_STRENGTH_GOOD */
+                    -95,  /* SIGNAL_STRENGTH_GREAT */
                 });
         sDefaults.putIntArray(KEY_5G_NR_SSRSRQ_THRESHOLDS_INT_ARRAY,
                 // Boundaries: [-43 dB, 20 dB]


### PR DESCRIPTION
The current aosp default SS-RSRP thresholds for 5G NR are too aggressive for real-world 5G SA deployments, causing devices to report a single signal bar even in areas with adequate and stable 5G SA coverage.

The previous thresholds required -65 dBm for GREAT signal, which represents near-peak conditions. Real-world 5G SA deployments typically operate in the -90 to -115 dBm range under good coverage conditions.

Update the defaults to reflect proper 5G SA signal levels:

  POOR:     -110 -> -125 dBm
  MODERATE:  -90 -> -115 dBm
  GOOD:      -80 -> -105 dBm
  GREAT:     -65 ->  -95 dBm

Tested after change:
signal bars respond dynamically, dropping appropriately during signal degradation and recovering correctly when conditions improve.

Note:
- This change only affects NR SA signal bar display.
- NR NSA networks are unaffected, as they use LTE RSRP thresholds via KEY_SIGNAL_STRENGTH_NR_NSA_USE_LTE_AS_PRIMARY_BOOL = true.
- Signal bar calculation uses only SS-RSRP by default per KEY_PARAMETERS_USE_FOR_5G_NR_SIGNAL_BAR_INT = USE_SSRSRP.
- Carrier-specific overrides via carrier config remain unaffected.

Change-Id: I8f4a92c18dc155369add2d4b37de00615be8bbb1