### PR TITLE
Fix composite BT keyboards getting suppressed

### DIFF
--- a/services/core/java/com/android/server/input/InputManagerService.java
+++ b/services/core/java/com/android/server/input/InputManagerService.java
@@ -2505,6 +2505,9 @@ public class InputManagerService extends IInputManager.Stub
             if ((device.getSources() & InputDevice.SOURCE_MOUSE) != InputDevice.SOURCE_MOUSE) {
                 continue;
             }
+            if ((device.getSources() & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD) {
+                continue;
+            }
             final String btAddress = mNative.getBluetoothAddress(id);
             if (btAddress == null) {
                 continue;


### PR DESCRIPTION
**The issue:**
The recent fix for phantom BT mice accidentally breaks composite keyboards (like trackpad combos or mechanical boards like the GMK67 that have mouse keys in their firmware), it connect fine but "InputReader" immediately drops all their inputs.

**Why it happens:**
These keyboards broadcast both "SOURCE_KEYBOARD" and "SOURCE_MOUSE" and the suppression loop catches the mouse flag, sees that the primary Bluetooth class is "Keyboard" instead of a dedicated pointer, assumes its a ghost mouse and kills the device