### PR TITLE
[bugfix] Ignore virtual displays on AxPcMode

### DIFF
--- a/services/core/java/com/android/server/AxPcModeService.java
+++ b/services/core/java/com/android/server/AxPcModeService.java
@@ -647,6 +647,16 @@ public class AxPcModeService implements IAxPcModeService {
                         + " uniqueId=" + info.uniqueId);
                 return;
             }
+            if (info != null
+                    && (info.ownerPackageName != null
+                            || info.type == Display.TYPE_VIRTUAL
+                            || info.type == Display.TYPE_OVERLAY)) {
+                Slog.d(TAG, "Ignoring non-external/app-owned display " + displayId
+                        + " type=" + info.type
+                        + " owner=" + info.ownerPackageName
+                        + " uniqueId=" + info.uniqueId);
+                return;
+            }
         }
         mHandler.post(() -> {
             setTargetDisplayId(displayId);


### PR DESCRIPTION
Fixes Android Auto bootloop on some weird resolutions ( https://github.com/AxionAOSP/issue_tracker/issues/313 ), because the configurable dpi messed up with the UI elements and enters in a bootloop state.

NOTE: I can't test with a real display because my phone (Nothing Phone 2a) doesn't have that capability, please check on a compatible device before accepting my PR!