### PR TITLE
SettingsProvider: Set device name to marketname if available

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2537,7 +2537,8 @@ class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     private String getDefaultDeviceName() {
-        return mContext.getResources().getString(R.string.def_device_name_simple, Build.MODEL);
+        return mContext.getResources().getString(R.string.def_device_name_simple,
+            SystemProperties.get("ro.product.marketname", Build.MODEL));
     }
 
     private TelephonyManager getTelephonyManager() {


### PR DESCRIPTION
 * model number on many devices differ from the actual device name, such as M2007J20CG/I on Poco X3 (surya) so use the market name as the default device name if its set by the device

Change-Id: Ifaaea4570d4952cc4715f5c546d61a1d05d565c3